### PR TITLE
Add interactive 100 Days of Python learning planner

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>100 Days of Python Learning Journey</title>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="hero">
+    <div class="hero__content">
+      <h1>Angela Yu's 100 Days of Code &mdash; Interactive Study Plan</h1>
+      <p>Track your progress, explore project briefs, and unlock curated resources as you move from Python basics to full-stack apps. Use the filters, search, and timeline view to tailor your learning experience.</p>
+      <div class="hero__actions">
+        <button id="toggleTimeline" class="btn btn--ghost">Toggle Timeline</button>
+        <button id="resetProgress" class="btn">Reset Progress</button>
+      </div>
+    </div>
+    <aside class="hero__stats">
+      <div class="stat-card">
+        <span class="stat-card__label">Days Completed</span>
+        <span id="completedCount" class="stat-card__value">0</span>
+      </div>
+      <div class="stat-card">
+        <span class="stat-card__label">Overall Progress</span>
+        <div class="progress" aria-hidden="true">
+          <div id="progressBar" class="progress__bar"></div>
+        </div>
+        <span id="progressPercent" class="stat-card__subvalue">0%</span>
+      </div>
+    </aside>
+  </header>
+
+  <main>
+    <section class="panel panel--filters">
+      <div class="filter-group">
+        <label for="searchInput">Search projects</label>
+        <input type="search" id="searchInput" placeholder="Search by project, concept, or tool..." />
+      </div>
+      <div class="filter-group">
+        <span class="filter-group__label">Stage</span>
+        <div id="stageFilters" class="chip-group" role="group" aria-label="Stage filters"></div>
+      </div>
+      <div class="filter-group">
+        <span class="filter-group__label">Focus</span>
+        <div id="focusFilters" class="chip-group" role="group" aria-label="Focus filters"></div>
+      </div>
+      <div class="filter-group">
+        <label class="toggle">
+          <input type="checkbox" id="completedToggle" />
+          <span>Show only incomplete days</span>
+        </label>
+      </div>
+    </section>
+
+    <section class="panel panel--timeline" id="timelineSection" hidden>
+      <h2>Stage Overview</h2>
+      <div id="timeline" class="timeline"></div>
+    </section>
+
+    <section class="panel">
+      <header class="panel__header">
+        <h2>Daily Challenges</h2>
+        <p>Check off lessons as you master them. Click a card to reveal the daily goals, Python concepts, and optional stretch ideas.</p>
+      </header>
+      <div id="cards" class="cards" role="list"></div>
+    </section>
+  </main>
+
+  <footer>
+    <p>Inspired by Angela Yu's <em>100 Days of Code: The Complete Python Pro Bootcamp</em>. This companion planner helps you stay organised and discover supporting resources.</p>
+  </footer>
+
+  <template id="cardTemplate">
+    <article class="card" role="listitem">
+      <header class="card__header">
+        <div>
+          <span class="card__day"></span>
+          <h3 class="card__title"></h3>
+        </div>
+        <label class="card__checkbox">
+          <input type="checkbox" />
+          <span>Done</span>
+        </label>
+      </header>
+      <div class="card__meta"></div>
+      <div class="card__body" hidden>
+        <p class="card__description"></p>
+        <ul class="card__concepts"></ul>
+        <div class="card__resources"></div>
+      </div>
+      <button class="card__toggle" aria-expanded="false">Details</button>
+    </article>
+  </template>
+
+  <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/lessons-data.js
+++ b/lessons-data.js
@@ -1,0 +1,3217 @@
+// Auto-generated lesson data
+export const stages = [
+  {
+    "id": "beginner",
+    "label": "Days 1–14 · Beginner",
+    "range": "1–14",
+    "summary": "Build Python fundamentals with simple control flow, functions, and beginner-friendly games."
+  },
+  {
+    "id": "intermediate",
+    "label": "Days 15–31 · Intermediate (OOP & GUI)",
+    "range": "15–31",
+    "summary": "Dive into object-oriented design, GUI programming with turtle and Tkinter, and modular projects."
+  },
+  {
+    "id": "automation",
+    "label": "Days 32–45 · APIs, Automation & Scraping",
+    "range": "32–45",
+    "summary": "Use external APIs, automate workflows, and scrape the web while managing secrets and data."
+  },
+  {
+    "id": "fullstack",
+    "label": "Days 46–70 · Selenium, Flask & Databases",
+    "range": "46–70",
+    "summary": "Automate the browser, build Flask apps, integrate databases, and prepare for deployment."
+  },
+  {
+    "id": "datascience",
+    "label": "Days 71–80 · Data Science & Visualisation",
+    "range": "71–80",
+    "summary": "Analyse datasets with pandas, NumPy, and visualisation libraries to uncover insights."
+  },
+  {
+    "id": "portfolio",
+    "label": "Days 81–100 · Portfolio Projects",
+    "range": "81–100",
+    "summary": "Ship polished apps, automation scripts, and analytical reports to showcase your Python mastery."
+  }
+];
+
+export const lessons = [
+  {
+    "day": 1,
+    "title": "Band Name Generator",
+    "stage": "beginner",
+    "focus": [
+      "Python Basics",
+      "Strings"
+    ],
+    "description": "Mix user inputs into fun band names to learn about variables and text.",
+    "concepts": [
+      "Input & output",
+      "Variables",
+      "Basic syntax",
+      "Concatenation"
+    ],
+    "stretch": [
+      "Handle invalid input",
+      "Refactor with functions",
+      "Add uppercase/lowercase options"
+    ],
+    "resources": [
+      {
+        "label": "Python tutorial",
+        "url": "https://docs.python.org/3/tutorial/"
+      },
+      {
+        "label": "String methods",
+        "url": "https://docs.python.org/3/library/stdtypes.html#textseq"
+      }
+    ]
+  },
+  {
+    "day": 2,
+    "title": "Tip Calculator",
+    "stage": "beginner",
+    "focus": [
+      "Python Basics",
+      "Math"
+    ],
+    "description": "Split bills and tips with numeric types and rounding practice.",
+    "concepts": [
+      "Input & output",
+      "Variables",
+      "Basic syntax",
+      "Arithmetic"
+    ],
+    "stretch": [
+      "Handle invalid input",
+      "Refactor with functions",
+      "Support more operators"
+    ],
+    "resources": [
+      {
+        "label": "Python tutorial",
+        "url": "https://docs.python.org/3/tutorial/"
+      },
+      {
+        "label": "Numeric types",
+        "url": "https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex"
+      }
+    ]
+  },
+  {
+    "day": 3,
+    "title": "Treasure Island",
+    "stage": "beginner",
+    "focus": [
+      "Conditionals",
+      "Games"
+    ],
+    "description": "Navigate a choose-your-own adventure using branching logic.",
+    "concepts": [
+      "if/elif/else",
+      "Logical operators",
+      "Branching",
+      "Game loops"
+    ],
+    "stretch": [
+      "Add more story paths",
+      "Track player choices",
+      "Add scoring"
+    ],
+    "resources": [
+      {
+        "label": "Control flow",
+        "url": "https://docs.python.org/3/tutorial/controlflow.html"
+      },
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      }
+    ]
+  },
+  {
+    "day": 4,
+    "title": "Rock–Paper–Scissors",
+    "stage": "beginner",
+    "focus": [
+      "Randomness",
+      "Games"
+    ],
+    "description": "Simulate classic hand battles against the computer.",
+    "concepts": [
+      "random module",
+      "Random choices",
+      "Shuffling",
+      "Game loops"
+    ],
+    "stretch": [
+      "Seed randomness",
+      "Add weighted choices",
+      "Add scoring"
+    ],
+    "resources": [
+      {
+        "label": "random docs",
+        "url": "https://docs.python.org/3/library/random.html"
+      },
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      }
+    ]
+  },
+  {
+    "day": 5,
+    "title": "Password Generator",
+    "stage": "beginner",
+    "focus": [
+      "Randomness",
+      "Security"
+    ],
+    "description": "Create secure passwords using loops and shuffling.",
+    "concepts": [
+      "random module",
+      "Random choices",
+      "Shuffling",
+      "Password strength"
+    ],
+    "stretch": [
+      "Seed randomness",
+      "Add weighted choices",
+      "Score password strength"
+    ],
+    "resources": [
+      {
+        "label": "random docs",
+        "url": "https://docs.python.org/3/library/random.html"
+      },
+      {
+        "label": "OWASP basics",
+        "url": "https://owasp.org/www-project-top-ten/"
+      }
+    ]
+  },
+  {
+    "day": 6,
+    "title": "Reeborg Maze",
+    "stage": "beginner",
+    "focus": [
+      "Functions",
+      "Problem Solving"
+    ],
+    "description": "Automate maze navigation with reusable helpers.",
+    "concepts": [
+      "Defining functions",
+      "Parameters",
+      "Return values",
+      "Decomposition"
+    ],
+    "stretch": [
+      "Add default parameters",
+      "Compose functions",
+      "Create extra challenges"
+    ],
+    "resources": [
+      {
+        "label": "Defining functions",
+        "url": "https://docs.python.org/3/tutorial/controlflow.html#defining-functions"
+      },
+      {
+        "label": "Problem solving patterns",
+        "url": "https://realpython.com/python-projects-for-beginners/"
+      }
+    ]
+  },
+  {
+    "day": 7,
+    "title": "Hangman",
+    "stage": "beginner",
+    "focus": [
+      "Loops",
+      "Games"
+    ],
+    "description": "Build a terminal hangman and manage multi-stage state.",
+    "concepts": [
+      "for loops",
+      "while loops",
+      "Loop control",
+      "Game loops"
+    ],
+    "stretch": [
+      "Add break conditions",
+      "Provide loop counters",
+      "Add scoring"
+    ],
+    "resources": [
+      {
+        "label": "Loop techniques",
+        "url": "https://docs.python.org/3/tutorial/controlflow.html#for-statements"
+      },
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      }
+    ]
+  },
+  {
+    "day": 8,
+    "title": "Caesar Cipher",
+    "stage": "beginner",
+    "focus": [
+      "Functions",
+      "Security"
+    ],
+    "description": "Encode and decode messages with shift ciphers.",
+    "concepts": [
+      "Defining functions",
+      "Parameters",
+      "Return values",
+      "Password strength"
+    ],
+    "stretch": [
+      "Add default parameters",
+      "Compose functions",
+      "Score password strength"
+    ],
+    "resources": [
+      {
+        "label": "Defining functions",
+        "url": "https://docs.python.org/3/tutorial/controlflow.html#defining-functions"
+      },
+      {
+        "label": "OWASP basics",
+        "url": "https://owasp.org/www-project-top-ten/"
+      }
+    ]
+  },
+  {
+    "day": 9,
+    "title": "Secret Auction",
+    "stage": "beginner",
+    "focus": [
+      "Dictionaries",
+      "CLI"
+    ],
+    "description": "Collect anonymous bids and determine the winner.",
+    "concepts": [
+      "Key/value pairs",
+      "Updating data",
+      "Lookup",
+      "User prompts"
+    ],
+    "stretch": [
+      "Persist to JSON",
+      "Handle missing keys",
+      "Add command history"
+    ],
+    "resources": [
+      {
+        "label": "Dictionary how-to",
+        "url": "https://realpython.com/python-dicts/"
+      },
+      {
+        "label": "argparse",
+        "url": "https://docs.python.org/3/library/argparse.html"
+      }
+    ]
+  },
+  {
+    "day": 10,
+    "title": "Calculator (Functions)",
+    "stage": "beginner",
+    "focus": [
+      "Functions",
+      "CLI"
+    ],
+    "description": "Compose a calculator using functions with return values.",
+    "concepts": [
+      "Defining functions",
+      "Parameters",
+      "Return values",
+      "User prompts"
+    ],
+    "stretch": [
+      "Add default parameters",
+      "Compose functions",
+      "Add command history"
+    ],
+    "resources": [
+      {
+        "label": "Defining functions",
+        "url": "https://docs.python.org/3/tutorial/controlflow.html#defining-functions"
+      },
+      {
+        "label": "argparse",
+        "url": "https://docs.python.org/3/library/argparse.html"
+      }
+    ]
+  },
+  {
+    "day": 11,
+    "title": "Blackjack",
+    "stage": "beginner",
+    "focus": [
+      "Games",
+      "Logic"
+    ],
+    "description": "Simulate Blackjack with card decks and scoring rules.",
+    "concepts": [
+      "Game loops",
+      "State tracking",
+      "User feedback",
+      "Boolean expressions"
+    ],
+    "stretch": [
+      "Add scoring",
+      "Increase difficulty",
+      "Add custom rules"
+    ],
+    "resources": [
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      },
+      {
+        "label": "Logic in Python",
+        "url": "https://realpython.com/python-boolean/"
+      }
+    ]
+  },
+  {
+    "day": 12,
+    "title": "Number Guessing",
+    "stage": "beginner",
+    "focus": [
+      "Scope",
+      "Games"
+    ],
+    "description": "Guess the number while exploring scope and constants.",
+    "concepts": [
+      "Local vs global",
+      "Constants",
+      "Namespaces",
+      "Game loops"
+    ],
+    "stretch": [
+      "Refactor to reduce globals",
+      "Write helper modules",
+      "Add scoring"
+    ],
+    "resources": [
+      {
+        "label": "Scope guide",
+        "url": "https://realpython.com/python-scope-legb-rule/"
+      },
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      }
+    ]
+  },
+  {
+    "day": 13,
+    "title": "Debugging Day",
+    "stage": "beginner",
+    "focus": [
+      "Debugging",
+      "Mindset"
+    ],
+    "description": "Practise debugging tactics and reading tracebacks.",
+    "concepts": [
+      "Tracebacks",
+      "Print debugging",
+      "Mindset",
+      "Growth mindset"
+    ],
+    "stretch": [
+      "Use a debugger",
+      "Create a checklist",
+      "Log lessons learned"
+    ],
+    "resources": [
+      {
+        "label": "pdb tutorial",
+        "url": "https://realpython.com/python-debugging-pdb/"
+      },
+      {
+        "label": "Learning mindset",
+        "url": "https://www.coursera.org/articles/growth-mindset"
+      }
+    ]
+  },
+  {
+    "day": 14,
+    "title": "Higher or Lower",
+    "stage": "beginner",
+    "focus": [
+      "APIs",
+      "Games"
+    ],
+    "description": "Compare celebrity reach using data-driven guessing.",
+    "concepts": [
+      "HTTP requests",
+      "JSON parsing",
+      "Endpoints",
+      "Game loops"
+    ],
+    "stretch": [
+      "Handle errors",
+      "Add retries",
+      "Add scoring"
+    ],
+    "resources": [
+      {
+        "label": "requests docs",
+        "url": "https://requests.readthedocs.io/"
+      },
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      }
+    ]
+  },
+  {
+    "day": 15,
+    "title": "Coffee Machine (Procedural)",
+    "stage": "intermediate",
+    "focus": [
+      "Procedural",
+      "CLI"
+    ],
+    "description": "Model a coffee machine with procedural state logic.",
+    "concepts": [
+      "State machines",
+      "Functions",
+      "Refactoring",
+      "User prompts"
+    ],
+    "stretch": [
+      "Extract modules",
+      "Add test cases",
+      "Add command history"
+    ],
+    "resources": [
+      {
+        "label": "Procedural patterns",
+        "url": "https://realpython.com/python-application-layouts/"
+      },
+      {
+        "label": "argparse",
+        "url": "https://docs.python.org/3/library/argparse.html"
+      }
+    ]
+  },
+  {
+    "day": 16,
+    "title": "Coffee Machine (OOP)",
+    "stage": "intermediate",
+    "focus": [
+      "OOP",
+      "CLI"
+    ],
+    "description": "Refactor the machine into collaborating classes.",
+    "concepts": [
+      "Classes",
+      "Instances",
+      "Encapsulation",
+      "User prompts"
+    ],
+    "stretch": [
+      "Introduce inheritance",
+      "Add unit tests",
+      "Add command history"
+    ],
+    "resources": [
+      {
+        "label": "OOP guide",
+        "url": "https://realpython.com/python3-object-oriented-programming/"
+      },
+      {
+        "label": "argparse",
+        "url": "https://docs.python.org/3/library/argparse.html"
+      }
+    ]
+  },
+  {
+    "day": 17,
+    "title": "Quiz Game",
+    "stage": "intermediate",
+    "focus": [
+      "OOP",
+      "Trivia"
+    ],
+    "description": "Build a quiz brain class fed by trivia data.",
+    "concepts": [
+      "Classes",
+      "Instances",
+      "Encapsulation",
+      "Question banks"
+    ],
+    "stretch": [
+      "Introduce inheritance",
+      "Add unit tests",
+      "Add categories"
+    ],
+    "resources": [
+      {
+        "label": "OOP guide",
+        "url": "https://realpython.com/python3-object-oriented-programming/"
+      },
+      {
+        "label": "Open Trivia DB",
+        "url": "https://opentdb.com/"
+      }
+    ]
+  },
+  {
+    "day": 18,
+    "title": "Hirst Painting",
+    "stage": "intermediate",
+    "focus": [
+      "Turtle",
+      "Visualisation"
+    ],
+    "description": "Paint dot art inspired by Damien Hirst using turtle.",
+    "concepts": [
+      "Coordinate system",
+      "Movement",
+      "Screen updates",
+      "Charts"
+    ],
+    "stretch": [
+      "Animate shapes",
+      "Add collision detection",
+      "Add interactivity"
+    ],
+    "resources": [
+      {
+        "label": "turtle docs",
+        "url": "https://docs.python.org/3/library/turtle.html"
+      },
+      {
+        "label": "Matplotlib",
+        "url": "https://matplotlib.org/stable/index.html"
+      }
+    ]
+  },
+  {
+    "day": 19,
+    "title": "Turtle Race",
+    "stage": "intermediate",
+    "focus": [
+      "Turtle",
+      "Events"
+    ],
+    "description": "Race turtles across the screen with event-driven updates.",
+    "concepts": [
+      "Coordinate system",
+      "Movement",
+      "Screen updates",
+      "Event listeners"
+    ],
+    "stretch": [
+      "Animate shapes",
+      "Add collision detection",
+      "Add keyboard shortcuts"
+    ],
+    "resources": [
+      {
+        "label": "turtle docs",
+        "url": "https://docs.python.org/3/library/turtle.html"
+      },
+      {
+        "label": "Event-driven programming",
+        "url": "https://realpython.com/event-driven-programming/"
+      }
+    ]
+  },
+  {
+    "day": 20,
+    "title": "Snake Game Pt.1",
+    "stage": "intermediate",
+    "focus": [
+      "Turtle",
+      "Games"
+    ],
+    "description": "Construct snake movement and collision detection.",
+    "concepts": [
+      "Coordinate system",
+      "Movement",
+      "Screen updates",
+      "Game loops"
+    ],
+    "stretch": [
+      "Animate shapes",
+      "Add collision detection",
+      "Add scoring"
+    ],
+    "resources": [
+      {
+        "label": "turtle docs",
+        "url": "https://docs.python.org/3/library/turtle.html"
+      },
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      }
+    ]
+  },
+  {
+    "day": 21,
+    "title": "Snake Game Pt.2",
+    "stage": "intermediate",
+    "focus": [
+      "File I/O",
+      "Games"
+    ],
+    "description": "Persist high scores and polish the snake game.",
+    "concepts": [
+      "Reading files",
+      "Writing files",
+      "Paths",
+      "Game loops"
+    ],
+    "stretch": [
+      "Use pathlib",
+      "Handle missing files",
+      "Add scoring"
+    ],
+    "resources": [
+      {
+        "label": "File handling",
+        "url": "https://docs.python.org/3/tutorial/inputoutput.html"
+      },
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      }
+    ]
+  },
+  {
+    "day": 22,
+    "title": "Pong",
+    "stage": "intermediate",
+    "focus": [
+      "Turtle",
+      "Games"
+    ],
+    "description": "Recreate Pong with paddles, ball physics, and scoring.",
+    "concepts": [
+      "Coordinate system",
+      "Movement",
+      "Screen updates",
+      "Game loops"
+    ],
+    "stretch": [
+      "Animate shapes",
+      "Add collision detection",
+      "Add scoring"
+    ],
+    "resources": [
+      {
+        "label": "turtle docs",
+        "url": "https://docs.python.org/3/library/turtle.html"
+      },
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      }
+    ]
+  },
+  {
+    "day": 23,
+    "title": "Turtle Crossing",
+    "stage": "intermediate",
+    "focus": [
+      "OOP",
+      "Games"
+    ],
+    "description": "Guide a turtle across traffic using classes and collisions.",
+    "concepts": [
+      "Classes",
+      "Instances",
+      "Encapsulation",
+      "Game loops"
+    ],
+    "stretch": [
+      "Introduce inheritance",
+      "Add unit tests",
+      "Add scoring"
+    ],
+    "resources": [
+      {
+        "label": "OOP guide",
+        "url": "https://realpython.com/python3-object-oriented-programming/"
+      },
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      }
+    ]
+  },
+  {
+    "day": 24,
+    "title": "Mail Merge",
+    "stage": "intermediate",
+    "focus": [
+      "File I/O",
+      "Automation"
+    ],
+    "description": "Personalise letters by combining templates and data.",
+    "concepts": [
+      "Reading files",
+      "Writing files",
+      "Paths",
+      "Scheduling"
+    ],
+    "stretch": [
+      "Use pathlib",
+      "Handle missing files",
+      "Add logging"
+    ],
+    "resources": [
+      {
+        "label": "File handling",
+        "url": "https://docs.python.org/3/tutorial/inputoutput.html"
+      },
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      }
+    ]
+  },
+  {
+    "day": 25,
+    "title": "U.S. States Game",
+    "stage": "intermediate",
+    "focus": [
+      "pandas",
+      "CSV"
+    ],
+    "description": "Guess U.S. states with CSV lookups and turtle labels.",
+    "concepts": [
+      "DataFrame basics",
+      "Filtering",
+      "Aggregation",
+      "CSV parsing"
+    ],
+    "stretch": [
+      "Create charts",
+      "Export cleaned data",
+      "Support export"
+    ],
+    "resources": [
+      {
+        "label": "pandas docs",
+        "url": "https://pandas.pydata.org/docs/"
+      },
+      {
+        "label": "CSV module",
+        "url": "https://docs.python.org/3/library/csv.html"
+      }
+    ]
+  },
+  {
+    "day": 26,
+    "title": "NATO Alphabet",
+    "stage": "intermediate",
+    "focus": [
+      "Comprehensions",
+      "Dictionaries"
+    ],
+    "description": "Convert words into NATO phonetics with comprehensions.",
+    "concepts": [
+      "List comprehensions",
+      "Dict comprehensions",
+      "Iteration",
+      "Key/value pairs"
+    ],
+    "stretch": [
+      "Create set comprehension",
+      "Refactor loops",
+      "Persist to JSON"
+    ],
+    "resources": [
+      {
+        "label": "Comprehensions guide",
+        "url": "https://realpython.com/list-comprehension-python/"
+      },
+      {
+        "label": "Dictionary how-to",
+        "url": "https://realpython.com/python-dicts/"
+      }
+    ]
+  },
+  {
+    "day": 27,
+    "title": "Mile ↔ Km Converter",
+    "stage": "intermediate",
+    "focus": [
+      "Tkinter",
+      "GUI"
+    ],
+    "description": "Convert between units via a simple Tkinter interface.",
+    "concepts": [
+      "Widgets",
+      "Layouts",
+      "Callbacks",
+      "Layout"
+    ],
+    "stretch": [
+      "Add styling",
+      "Support keyboard shortcuts",
+      "Add icons"
+    ],
+    "resources": [
+      {
+        "label": "Tkinter reference",
+        "url": "https://docs.python.org/3/library/tk.html"
+      },
+      {
+        "label": "GUI design tips",
+        "url": "https://realpython.com/python-gui-tkinter/"
+      }
+    ]
+  },
+  {
+    "day": 28,
+    "title": "Pomodoro Timer",
+    "stage": "intermediate",
+    "focus": [
+      "Tkinter",
+      "Productivity"
+    ],
+    "description": "Create a productivity timer with work/break cycles.",
+    "concepts": [
+      "Widgets",
+      "Layouts",
+      "Callbacks",
+      "Timers"
+    ],
+    "stretch": [
+      "Add styling",
+      "Support keyboard shortcuts",
+      "Track sessions"
+    ],
+    "resources": [
+      {
+        "label": "Tkinter reference",
+        "url": "https://docs.python.org/3/library/tk.html"
+      },
+      {
+        "label": "Pomodoro method",
+        "url": "https://todoist.com/productivity-methods/pomodoro-technique"
+      }
+    ]
+  },
+  {
+    "day": 29,
+    "title": "Password Manager GUI",
+    "stage": "intermediate",
+    "focus": [
+      "Tkinter",
+      "Security"
+    ],
+    "description": "Store generated passwords with a friendly GUI.",
+    "concepts": [
+      "Widgets",
+      "Layouts",
+      "Callbacks",
+      "Password strength"
+    ],
+    "stretch": [
+      "Add styling",
+      "Support keyboard shortcuts",
+      "Score password strength"
+    ],
+    "resources": [
+      {
+        "label": "Tkinter reference",
+        "url": "https://docs.python.org/3/library/tk.html"
+      },
+      {
+        "label": "OWASP basics",
+        "url": "https://owasp.org/www-project-top-ten/"
+      }
+    ]
+  },
+  {
+    "day": 30,
+    "title": "Password Manager JSON",
+    "stage": "intermediate",
+    "focus": [
+      "Persistence",
+      "Tkinter"
+    ],
+    "description": "Persist credentials safely using JSON storage.",
+    "concepts": [
+      "File storage",
+      "JSON",
+      "Data retrieval",
+      "Widgets"
+    ],
+    "stretch": [
+      "Encrypt data",
+      "Add backups",
+      "Add styling"
+    ],
+    "resources": [
+      {
+        "label": "JSON guide",
+        "url": "https://docs.python.org/3/library/json.html"
+      },
+      {
+        "label": "Tkinter reference",
+        "url": "https://docs.python.org/3/library/tk.html"
+      }
+    ]
+  },
+  {
+    "day": 31,
+    "title": "Flash Card App",
+    "stage": "intermediate",
+    "focus": [
+      "Learning",
+      "Tkinter"
+    ],
+    "description": "Flip flash cards and track vocabulary progress.",
+    "concepts": [
+      "Spaced repetition",
+      "Flash cards",
+      "Progress tracking",
+      "Widgets"
+    ],
+    "stretch": [
+      "Add custom decks",
+      "Record accuracy",
+      "Add styling"
+    ],
+    "resources": [
+      {
+        "label": "Learning science",
+        "url": "https://www.learningscientists.org/"
+      },
+      {
+        "label": "Tkinter reference",
+        "url": "https://docs.python.org/3/library/tk.html"
+      }
+    ]
+  },
+  {
+    "day": 32,
+    "title": "Birthday Wisher",
+    "stage": "automation",
+    "focus": [
+      "Automation",
+      "Email"
+    ],
+    "description": "Send automated birthday greetings via SMTP.",
+    "concepts": [
+      "Scheduling",
+      "APIs",
+      "Workflows",
+      "SMTP"
+    ],
+    "stretch": [
+      "Add logging",
+      "Deploy to cloud",
+      "Send HTML"
+    ],
+    "resources": [
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      },
+      {
+        "label": "smtplib docs",
+        "url": "https://docs.python.org/3/library/smtplib.html"
+      }
+    ]
+  },
+  {
+    "day": 33,
+    "title": "ISS Overhead Notifier",
+    "stage": "automation",
+    "focus": [
+      "Automation",
+      "APIs"
+    ],
+    "description": "Alert when the ISS flies above at night.",
+    "concepts": [
+      "Scheduling",
+      "APIs",
+      "Workflows",
+      "HTTP requests"
+    ],
+    "stretch": [
+      "Add logging",
+      "Deploy to cloud",
+      "Handle errors"
+    ],
+    "resources": [
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      },
+      {
+        "label": "requests docs",
+        "url": "https://requests.readthedocs.io/"
+      }
+    ]
+  },
+  {
+    "day": 34,
+    "title": "Quizzler API",
+    "stage": "automation",
+    "focus": [
+      "APIs",
+      "Tkinter"
+    ],
+    "description": "Feed your quiz GUI live questions from an API.",
+    "concepts": [
+      "HTTP requests",
+      "JSON parsing",
+      "Endpoints",
+      "Widgets"
+    ],
+    "stretch": [
+      "Handle errors",
+      "Add retries",
+      "Add styling"
+    ],
+    "resources": [
+      {
+        "label": "requests docs",
+        "url": "https://requests.readthedocs.io/"
+      },
+      {
+        "label": "Tkinter reference",
+        "url": "https://docs.python.org/3/library/tk.html"
+      }
+    ]
+  },
+  {
+    "day": 35,
+    "title": "Rain Alert SMS",
+    "stage": "automation",
+    "focus": [
+      "Automation",
+      "APIs"
+    ],
+    "description": "Warn yourself about rain using weather data and SMS.",
+    "concepts": [
+      "Scheduling",
+      "APIs",
+      "Workflows",
+      "HTTP requests"
+    ],
+    "stretch": [
+      "Add logging",
+      "Deploy to cloud",
+      "Handle errors"
+    ],
+    "resources": [
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      },
+      {
+        "label": "requests docs",
+        "url": "https://requests.readthedocs.io/"
+      }
+    ]
+  },
+  {
+    "day": 36,
+    "title": "Stock News SMS",
+    "stage": "automation",
+    "focus": [
+      "Finance",
+      "APIs"
+    ],
+    "description": "Monitor stocks and push relevant headlines by text.",
+    "concepts": [
+      "Market data",
+      "Alerts",
+      "Percent change",
+      "HTTP requests"
+    ],
+    "stretch": [
+      "Track multiple tickers",
+      "Send summary reports",
+      "Handle errors"
+    ],
+    "resources": [
+      {
+        "label": "Alpha Vantage",
+        "url": "https://www.alphavantage.co/"
+      },
+      {
+        "label": "requests docs",
+        "url": "https://requests.readthedocs.io/"
+      }
+    ]
+  },
+  {
+    "day": 37,
+    "title": "Habit Tracker",
+    "stage": "automation",
+    "focus": [
+      "Automation",
+      "Visualisation"
+    ],
+    "description": "Log daily habits to an external API chart.",
+    "concepts": [
+      "Scheduling",
+      "APIs",
+      "Workflows",
+      "Charts"
+    ],
+    "stretch": [
+      "Add logging",
+      "Deploy to cloud",
+      "Add interactivity"
+    ],
+    "resources": [
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      },
+      {
+        "label": "Matplotlib",
+        "url": "https://matplotlib.org/stable/index.html"
+      }
+    ]
+  },
+  {
+    "day": 38,
+    "title": "Workout Tracker",
+    "stage": "automation",
+    "focus": [
+      "Automation",
+      "Google Sheets"
+    ],
+    "description": "Record workouts from natural language into Sheets.",
+    "concepts": [
+      "Scheduling",
+      "APIs",
+      "Workflows",
+      "Sheet updates"
+    ],
+    "stretch": [
+      "Add logging",
+      "Deploy to cloud",
+      "Visualise metrics"
+    ],
+    "resources": [
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      },
+      {
+        "label": "Sheety",
+        "url": "https://sheety.co/docs"
+      }
+    ]
+  },
+  {
+    "day": 39,
+    "title": "Flight Deal Finder",
+    "stage": "automation",
+    "focus": [
+      "Automation",
+      "APIs"
+    ],
+    "description": "Monitor airfare deals and notify travellers.",
+    "concepts": [
+      "Scheduling",
+      "APIs",
+      "Workflows",
+      "HTTP requests"
+    ],
+    "stretch": [
+      "Add logging",
+      "Deploy to cloud",
+      "Handle errors"
+    ],
+    "resources": [
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      },
+      {
+        "label": "requests docs",
+        "url": "https://requests.readthedocs.io/"
+      }
+    ]
+  },
+  {
+    "day": 40,
+    "title": "Flight Club",
+    "stage": "automation",
+    "focus": [
+      "Automation",
+      "Email"
+    ],
+    "description": "Manage a flight club mailing list with price alerts.",
+    "concepts": [
+      "Scheduling",
+      "APIs",
+      "Workflows",
+      "SMTP"
+    ],
+    "stretch": [
+      "Add logging",
+      "Deploy to cloud",
+      "Send HTML"
+    ],
+    "resources": [
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      },
+      {
+        "label": "smtplib docs",
+        "url": "https://docs.python.org/3/library/smtplib.html"
+      }
+    ]
+  },
+  {
+    "day": 41,
+    "title": "Personal Site",
+    "stage": "automation",
+    "focus": [
+      "HTML/CSS",
+      "Portfolio"
+    ],
+    "description": "Launch a simple personal web page.",
+    "concepts": [
+      "Semantic HTML",
+      "Styling",
+      "Layout",
+      "Showcasing work"
+    ],
+    "stretch": [
+      "Add responsive design",
+      "Use CSS variables",
+      "Add case studies"
+    ],
+    "resources": [
+      {
+        "label": "MDN HTML",
+        "url": "https://developer.mozilla.org/en-US/docs/Learn/HTML"
+      },
+      {
+        "label": "Portfolio tips",
+        "url": "https://www.freecodecamp.org/news/portfolio-advice/"
+      }
+    ]
+  },
+  {
+    "day": 42,
+    "title": "HTML Forms & Tables",
+    "stage": "automation",
+    "focus": [
+      "HTML/CSS",
+      "Web"
+    ],
+    "description": "Practise building accessible forms and tables.",
+    "concepts": [
+      "Semantic HTML",
+      "Styling",
+      "Layout",
+      "Structure"
+    ],
+    "stretch": [
+      "Add responsive design",
+      "Use CSS variables",
+      "Deploy site"
+    ],
+    "resources": [
+      {
+        "label": "MDN HTML",
+        "url": "https://developer.mozilla.org/en-US/docs/Learn/HTML"
+      },
+      {
+        "label": "MDN Web",
+        "url": "https://developer.mozilla.org/en-US/docs/Learn"
+      }
+    ]
+  },
+  {
+    "day": 43,
+    "title": "CSS Foundations",
+    "stage": "automation",
+    "focus": [
+      "HTML/CSS",
+      "Design"
+    ],
+    "description": "Strengthen CSS fundamentals and selectors.",
+    "concepts": [
+      "Semantic HTML",
+      "Styling",
+      "Layout",
+      "Colour"
+    ],
+    "stretch": [
+      "Add responsive design",
+      "Use CSS variables",
+      "Create style guide"
+    ],
+    "resources": [
+      {
+        "label": "MDN HTML",
+        "url": "https://developer.mozilla.org/en-US/docs/Learn/HTML"
+      },
+      {
+        "label": "Refactoring UI",
+        "url": "https://refactoringui.com/book/"
+      }
+    ]
+  },
+  {
+    "day": 44,
+    "title": "CSS Layouts",
+    "stage": "automation",
+    "focus": [
+      "HTML/CSS",
+      "Design"
+    ],
+    "description": "Experiment with flexbox and grid layouts.",
+    "concepts": [
+      "Semantic HTML",
+      "Styling",
+      "Layout",
+      "Colour"
+    ],
+    "stretch": [
+      "Add responsive design",
+      "Use CSS variables",
+      "Create style guide"
+    ],
+    "resources": [
+      {
+        "label": "MDN HTML",
+        "url": "https://developer.mozilla.org/en-US/docs/Learn/HTML"
+      },
+      {
+        "label": "Refactoring UI",
+        "url": "https://refactoringui.com/book/"
+      }
+    ]
+  },
+  {
+    "day": 45,
+    "title": "Top 100 Movies Scraper",
+    "stage": "automation",
+    "focus": [
+      "BeautifulSoup",
+      "Scraping"
+    ],
+    "description": "Scrape a movie ranking site into a list.",
+    "concepts": [
+      "HTML parsing",
+      "Selectors",
+      "Data extraction",
+      "HTTP requests"
+    ],
+    "stretch": [
+      "Handle pagination",
+      "Export to CSV",
+      "Respect robots.txt"
+    ],
+    "resources": [
+      {
+        "label": "BeautifulSoup docs",
+        "url": "https://www.crummy.com/software/BeautifulSoup/bs4/doc/"
+      },
+      {
+        "label": "Scraping guide",
+        "url": "https://docs.python-guide.org/scenarios/scrape/"
+      }
+    ]
+  },
+  {
+    "day": 46,
+    "title": "Spotify Time Machine",
+    "stage": "fullstack",
+    "focus": [
+      "APIs",
+      "Automation"
+    ],
+    "description": "Build nostalgic Spotify playlists from chart data.",
+    "concepts": [
+      "HTTP requests",
+      "JSON parsing",
+      "Endpoints",
+      "Scheduling"
+    ],
+    "stretch": [
+      "Handle errors",
+      "Add retries",
+      "Add logging"
+    ],
+    "resources": [
+      {
+        "label": "requests docs",
+        "url": "https://requests.readthedocs.io/"
+      },
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      }
+    ]
+  },
+  {
+    "day": 47,
+    "title": "Amazon Price Tracker",
+    "stage": "fullstack",
+    "focus": [
+      "Scraping",
+      "Automation"
+    ],
+    "description": "Track product prices and send alerts.",
+    "concepts": [
+      "HTTP requests",
+      "Parsing",
+      "Throttling",
+      "Scheduling"
+    ],
+    "stretch": [
+      "Respect robots.txt",
+      "Add caching",
+      "Add logging"
+    ],
+    "resources": [
+      {
+        "label": "Scraping guide",
+        "url": "https://docs.python-guide.org/scenarios/scrape/"
+      },
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      }
+    ]
+  },
+  {
+    "day": 48,
+    "title": "Selenium Cookie Clicker",
+    "stage": "fullstack",
+    "focus": [
+      "Selenium",
+      "Automation"
+    ],
+    "description": "Automate the cookie-clicker browser game.",
+    "concepts": [
+      "WebDriver",
+      "Locators",
+      "Automation",
+      "Scheduling"
+    ],
+    "stretch": [
+      "Use explicit waits",
+      "Handle errors",
+      "Add logging"
+    ],
+    "resources": [
+      {
+        "label": "Selenium docs",
+        "url": "https://www.selenium.dev/documentation/webdriver/"
+      },
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      }
+    ]
+  },
+  {
+    "day": 49,
+    "title": "LinkedIn Auto Apply Bot",
+    "stage": "fullstack",
+    "focus": [
+      "Selenium",
+      "Automation"
+    ],
+    "description": "Autofill job applications with Selenium.",
+    "concepts": [
+      "WebDriver",
+      "Locators",
+      "Automation",
+      "Scheduling"
+    ],
+    "stretch": [
+      "Use explicit waits",
+      "Handle errors",
+      "Add logging"
+    ],
+    "resources": [
+      {
+        "label": "Selenium docs",
+        "url": "https://www.selenium.dev/documentation/webdriver/"
+      },
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      }
+    ]
+  },
+  {
+    "day": 50,
+    "title": "Tinder Auto-Swiper",
+    "stage": "fullstack",
+    "focus": [
+      "Selenium",
+      "Automation"
+    ],
+    "description": "Automate swipes while respecting rate limits.",
+    "concepts": [
+      "WebDriver",
+      "Locators",
+      "Automation",
+      "Scheduling"
+    ],
+    "stretch": [
+      "Use explicit waits",
+      "Handle errors",
+      "Add logging"
+    ],
+    "resources": [
+      {
+        "label": "Selenium docs",
+        "url": "https://www.selenium.dev/documentation/webdriver/"
+      },
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      }
+    ]
+  },
+  {
+    "day": 51,
+    "title": "Internet-Speed Twitter Bot",
+    "stage": "fullstack",
+    "focus": [
+      "Selenium",
+      "APIs"
+    ],
+    "description": "Tweet complaints when speeds dip below promises.",
+    "concepts": [
+      "WebDriver",
+      "Locators",
+      "Automation",
+      "HTTP requests"
+    ],
+    "stretch": [
+      "Use explicit waits",
+      "Handle errors",
+      "Add retries"
+    ],
+    "resources": [
+      {
+        "label": "Selenium docs",
+        "url": "https://www.selenium.dev/documentation/webdriver/"
+      },
+      {
+        "label": "requests docs",
+        "url": "https://requests.readthedocs.io/"
+      }
+    ]
+  },
+  {
+    "day": 52,
+    "title": "Instagram Follower Bot",
+    "stage": "fullstack",
+    "focus": [
+      "Selenium",
+      "Automation"
+    ],
+    "description": "Grow accounts automatically with safe throttling.",
+    "concepts": [
+      "WebDriver",
+      "Locators",
+      "Automation",
+      "Scheduling"
+    ],
+    "stretch": [
+      "Use explicit waits",
+      "Handle errors",
+      "Add logging"
+    ],
+    "resources": [
+      {
+        "label": "Selenium docs",
+        "url": "https://www.selenium.dev/documentation/webdriver/"
+      },
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      }
+    ]
+  },
+  {
+    "day": 53,
+    "title": "Data Entry Automation",
+    "stage": "fullstack",
+    "focus": [
+      "Selenium",
+      "Automation"
+    ],
+    "description": "Fill forms from scraped real estate data.",
+    "concepts": [
+      "WebDriver",
+      "Locators",
+      "Automation",
+      "Scheduling"
+    ],
+    "stretch": [
+      "Use explicit waits",
+      "Handle errors",
+      "Add logging"
+    ],
+    "resources": [
+      {
+        "label": "Selenium docs",
+        "url": "https://www.selenium.dev/documentation/webdriver/"
+      },
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      }
+    ]
+  },
+  {
+    "day": 54,
+    "title": "Flask Quickstart",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "Web"
+    ],
+    "description": "Spin up routes and templates in Flask.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Structure"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Deploy site"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "MDN Web",
+        "url": "https://developer.mozilla.org/en-US/docs/Learn"
+      }
+    ]
+  },
+  {
+    "day": 55,
+    "title": "Flask Higher/Lower",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "Games"
+    ],
+    "description": "Port the higher/lower game to the web.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Game loops"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add scoring"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      }
+    ]
+  },
+  {
+    "day": 56,
+    "title": "Name Card Site",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "Portfolio"
+    ],
+    "description": "Serve a personal name card with static assets.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Showcasing work"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add case studies"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "Portfolio tips",
+        "url": "https://www.freecodecamp.org/news/portfolio-advice/"
+      }
+    ]
+  },
+  {
+    "day": 57,
+    "title": "Blog Capstone Pt.1",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "Blog"
+    ],
+    "description": "Build a dynamic blog with templating.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Posts"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add tags"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "Blog tutorial",
+        "url": "https://flask.palletsprojects.com/en/2.3.x/tutorial/blog/"
+      }
+    ]
+  },
+  {
+    "day": 58,
+    "title": "TinDog",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "Bootstrap"
+    ],
+    "description": "Create a playful marketing site with Bootstrap.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Components"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Customise theme"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "Bootstrap docs",
+        "url": "https://getbootstrap.com/docs/5.3/"
+      }
+    ]
+  },
+  {
+    "day": 59,
+    "title": "Blog Capstone Pt.2",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "Design"
+    ],
+    "description": "Polish blog styling and add contact forms.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Colour"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Create style guide"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "Refactoring UI",
+        "url": "https://refactoringui.com/book/"
+      }
+    ]
+  },
+  {
+    "day": 60,
+    "title": "Flask POST + Email",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "Email"
+    ],
+    "description": "Handle POST requests and send emails from forms.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "SMTP"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Send HTML"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "smtplib docs",
+        "url": "https://docs.python.org/3/library/smtplib.html"
+      }
+    ]
+  },
+  {
+    "day": 61,
+    "title": "Flask WTForms",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "Forms"
+    ],
+    "description": "Validate data using Flask-WTF.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Validation"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add file uploads"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "WTForms",
+        "url": "https://wtforms.readthedocs.io/"
+      }
+    ]
+  },
+  {
+    "day": 62,
+    "title": "Coffee & Wifi",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "CSV"
+    ],
+    "description": "Review cafés and wifi speeds with CSV storage.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "CSV parsing"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Support export"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "CSV module",
+        "url": "https://docs.python.org/3/library/csv.html"
+      }
+    ]
+  },
+  {
+    "day": 63,
+    "title": "Virtual Bookshelf",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "Databases"
+    ],
+    "description": "Manage books using SQLAlchemy CRUD.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Models"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add migrations"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "SQLAlchemy",
+        "url": "https://docs.sqlalchemy.org/"
+      }
+    ]
+  },
+  {
+    "day": 64,
+    "title": "Top 10 Movies",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "Databases"
+    ],
+    "description": "Rank favourite films with API lookups.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Models"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add migrations"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "SQLAlchemy",
+        "url": "https://docs.sqlalchemy.org/"
+      }
+    ]
+  },
+  {
+    "day": 65,
+    "title": "Web Design School",
+    "stage": "fullstack",
+    "focus": [
+      "Design",
+      "Portfolio"
+    ],
+    "description": "Refine UX polish across your projects.",
+    "concepts": [
+      "Colour",
+      "Typography",
+      "Spacing",
+      "Showcasing work"
+    ],
+    "stretch": [
+      "Create style guide",
+      "Audit accessibility",
+      "Add case studies"
+    ],
+    "resources": [
+      {
+        "label": "Refactoring UI",
+        "url": "https://refactoringui.com/book/"
+      },
+      {
+        "label": "Portfolio tips",
+        "url": "https://www.freecodecamp.org/news/portfolio-advice/"
+      }
+    ]
+  },
+  {
+    "day": 66,
+    "title": "Build a REST API",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "REST APIs"
+    ],
+    "description": "Expose CRUD endpoints with documentation.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "HTTP verbs"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add docs"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "REST design",
+        "url": "https://restfulapi.net/"
+      }
+    ]
+  },
+  {
+    "day": 67,
+    "title": "Blog REST API",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "REST APIs"
+    ],
+    "description": "Add REST endpoints to your blog.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "HTTP verbs"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add docs"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "REST design",
+        "url": "https://restfulapi.net/"
+      }
+    ]
+  },
+  {
+    "day": 68,
+    "title": "Auth with Flask",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "Auth"
+    ],
+    "description": "Secure routes with hashing and sessions.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Hashing"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add roles"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "Flask-Login",
+        "url": "https://flask-login.readthedocs.io/"
+      }
+    ]
+  },
+  {
+    "day": 69,
+    "title": "Blog Users & Roles",
+    "stage": "fullstack",
+    "focus": [
+      "Flask",
+      "Auth"
+    ],
+    "description": "Add role-based permissions and comments.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Hashing"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add roles"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "Flask-Login",
+        "url": "https://flask-login.readthedocs.io/"
+      }
+    ]
+  },
+  {
+    "day": 70,
+    "title": "Deploy Flask App",
+    "stage": "fullstack",
+    "focus": [
+      "Deploy",
+      "DevOps"
+    ],
+    "description": "Ship your Flask app to the web.",
+    "concepts": [
+      "Hosting",
+      "Procfile",
+      "Environment variables",
+      "Automation"
+    ],
+    "stretch": [
+      "Set up CI",
+      "Add monitoring",
+      "Add Docker"
+    ],
+    "resources": [
+      {
+        "label": "Render guide",
+        "url": "https://render.com/docs/deploy-flask"
+      },
+      {
+        "label": "CI/CD primer",
+        "url": "https://circleci.com/blog/what-is-ci-cd/"
+      }
+    ]
+  },
+  {
+    "day": 71,
+    "title": "College Majors vs Salary",
+    "stage": "datascience",
+    "focus": [
+      "pandas",
+      "Visualisation"
+    ],
+    "description": "Analyse major vs salary relationships.",
+    "concepts": [
+      "DataFrame basics",
+      "Filtering",
+      "Aggregation",
+      "Charts"
+    ],
+    "stretch": [
+      "Create charts",
+      "Export cleaned data",
+      "Add interactivity"
+    ],
+    "resources": [
+      {
+        "label": "pandas docs",
+        "url": "https://pandas.pydata.org/docs/"
+      },
+      {
+        "label": "Matplotlib",
+        "url": "https://matplotlib.org/stable/index.html"
+      }
+    ]
+  },
+  {
+    "day": 72,
+    "title": "Matplotlib Languages",
+    "stage": "datascience",
+    "focus": [
+      "Visualisation",
+      "Statistics"
+    ],
+    "description": "Chart language popularity trends.",
+    "concepts": [
+      "Charts",
+      "Colour",
+      "Storytelling",
+      "Distributions"
+    ],
+    "stretch": [
+      "Add interactivity",
+      "Compare categories",
+      "Calculate confidence intervals"
+    ],
+    "resources": [
+      {
+        "label": "Matplotlib",
+        "url": "https://matplotlib.org/stable/index.html"
+      },
+      {
+        "label": "Statistics primer",
+        "url": "https://seeing-theory.brown.edu/"
+      }
+    ]
+  },
+  {
+    "day": 73,
+    "title": "LEGO Dataset",
+    "stage": "datascience",
+    "focus": [
+      "pandas",
+      "EDA"
+    ],
+    "description": "Explore the LEGO parts database.",
+    "concepts": [
+      "DataFrame basics",
+      "Filtering",
+      "Aggregation",
+      "Exploratory analysis",
+      "Data profiling",
+      "Visualization planning"
+    ],
+    "stretch": [
+      "Create charts",
+      "Export cleaned data",
+      "Compare metrics across segments",
+      "Summarise key findings in a brief report"
+    ],
+    "resources": [
+      {
+        "label": "pandas docs",
+        "url": "https://pandas.pydata.org/docs/"
+      },
+      {
+        "label": "EDA checklist",
+        "url": "https://towardsdatascience.com/exploratory-data-analysis-8fc1cb20fd15"
+      }
+    ]
+  },
+  {
+    "day": 74,
+    "title": "Google Trends",
+    "stage": "datascience",
+    "focus": [
+      "Time Series",
+      "pandas"
+    ],
+    "description": "Resample trends data across years.",
+    "concepts": [
+      "Resampling",
+      "Rolling averages",
+      "Trends",
+      "DataFrame basics"
+    ],
+    "stretch": [
+      "Forecast future",
+      "Compare intervals",
+      "Create charts"
+    ],
+    "resources": [
+      {
+        "label": "Time series analysis",
+        "url": "https://pandas.pydata.org/docs/user_guide/timeseries.html"
+      },
+      {
+        "label": "pandas docs",
+        "url": "https://pandas.pydata.org/docs/"
+      }
+    ]
+  },
+  {
+    "day": 75,
+    "title": "Plotly Android Apps",
+    "stage": "datascience",
+    "focus": [
+      "Plotly",
+      "Data Viz"
+    ],
+    "description": "Build interactive app store dashboards.",
+    "concepts": [
+      "Interactive charts",
+      "Dashboards",
+      "Styling",
+      "Storytelling"
+    ],
+    "stretch": [
+      "Add filters",
+      "Embed visuals",
+      "Add annotations"
+    ],
+    "resources": [
+      {
+        "label": "Plotly docs",
+        "url": "https://plotly.com/python/"
+      },
+      {
+        "label": "Data Viz Handbook",
+        "url": "https://datavizcatalogue.com/"
+      }
+    ]
+  },
+  {
+    "day": 76,
+    "title": "NumPy & n-D Arrays",
+    "stage": "datascience",
+    "focus": [
+      "NumPy",
+      "Arrays"
+    ],
+    "description": "Practise fast array maths with NumPy.",
+    "concepts": [
+      "ndarray",
+      "Broadcasting",
+      "Vectorisation",
+      "Indexing"
+    ],
+    "stretch": [
+      "Benchmark operations",
+      "Use slicing",
+      "Reshape data"
+    ],
+    "resources": [
+      {
+        "label": "NumPy quickstart",
+        "url": "https://numpy.org/doc/stable/user/quickstart.html"
+      },
+      {
+        "label": "Array operations",
+        "url": "https://numpy.org/doc/stable/reference/routines.array-creation.html"
+      }
+    ]
+  },
+  {
+    "day": 77,
+    "title": "Linear Regression + Seaborn",
+    "stage": "datascience",
+    "focus": [
+      "Seaborn",
+      "Regression"
+    ],
+    "description": "Model trends with Seaborn regressions.",
+    "concepts": [
+      "Statistical plots",
+      "Themes",
+      "Regression",
+      "Linear models"
+    ],
+    "stretch": [
+      "Custom palettes",
+      "Facet charts",
+      "Add regularisation"
+    ],
+    "resources": [
+      {
+        "label": "Seaborn tutorials",
+        "url": "https://seaborn.pydata.org/tutorial.html"
+      },
+      {
+        "label": "Regression guide",
+        "url": "https://realpython.com/linear-regression-in-python/"
+      }
+    ]
+  },
+  {
+    "day": 78,
+    "title": "Nobel Prize Analysis",
+    "stage": "datascience",
+    "focus": [
+      "Data Viz",
+      "Statistics"
+    ],
+    "description": "Tell stories with Nobel Prize data.",
+    "concepts": [
+      "Storytelling",
+      "Design",
+      "Audience",
+      "Distributions"
+    ],
+    "stretch": [
+      "Add annotations",
+      "Compare categories",
+      "Calculate confidence intervals"
+    ],
+    "resources": [
+      {
+        "label": "Data Viz Handbook",
+        "url": "https://datavizcatalogue.com/"
+      },
+      {
+        "label": "Statistics primer",
+        "url": "https://seeing-theory.brown.edu/"
+      }
+    ]
+  },
+  {
+    "day": 79,
+    "title": "Handwashing Discovery",
+    "stage": "datascience",
+    "focus": [
+      "Statistics",
+      "Hypothesis Testing"
+    ],
+    "description": "Investigate Semmelweis' findings.",
+    "concepts": [
+      "Distributions",
+      "Inference",
+      "Significance",
+      "Null hypothesis"
+    ],
+    "stretch": [
+      "Calculate confidence intervals",
+      "Explain findings",
+      "Run additional tests"
+    ],
+    "resources": [
+      {
+        "label": "Statistics primer",
+        "url": "https://seeing-theory.brown.edu/"
+      },
+      {
+        "label": "Hypothesis testing",
+        "url": "https://realpython.com/python-hypothesis-testing/"
+      }
+    ]
+  },
+  {
+    "day": 80,
+    "title": "Predict House Prices",
+    "stage": "datascience",
+    "focus": [
+      "Machine Learning",
+      "Regression"
+    ],
+    "description": "Predict housing prices with ML.",
+    "concepts": [
+      "Modeling",
+      "Feature engineering",
+      "Evaluation",
+      "Linear models"
+    ],
+    "stretch": [
+      "Tune hyperparameters",
+      "Compare algorithms",
+      "Add regularisation"
+    ],
+    "resources": [
+      {
+        "label": "scikit-learn",
+        "url": "https://scikit-learn.org/stable/"
+      },
+      {
+        "label": "Regression guide",
+        "url": "https://realpython.com/linear-regression-in-python/"
+      }
+    ]
+  },
+  {
+    "day": 81,
+    "title": "Text → Morse Code",
+    "stage": "portfolio",
+    "focus": [
+      "CLI",
+      "Strings"
+    ],
+    "description": "Translate text to Morse code programmatically.",
+    "concepts": [
+      "User prompts",
+      "Program flow",
+      "Error handling",
+      "Concatenation"
+    ],
+    "stretch": [
+      "Add command history",
+      "Style output",
+      "Add uppercase/lowercase options"
+    ],
+    "resources": [
+      {
+        "label": "argparse",
+        "url": "https://docs.python.org/3/library/argparse.html"
+      },
+      {
+        "label": "String methods",
+        "url": "https://docs.python.org/3/library/stdtypes.html#textseq"
+      }
+    ]
+  },
+  {
+    "day": 82,
+    "title": "Portfolio Website",
+    "stage": "portfolio",
+    "focus": [
+      "HTML/CSS",
+      "Portfolio"
+    ],
+    "description": "Showcase your projects with flair.",
+    "concepts": [
+      "Semantic HTML",
+      "Styling",
+      "Layout",
+      "Showcasing work"
+    ],
+    "stretch": [
+      "Add responsive design",
+      "Use CSS variables",
+      "Add case studies"
+    ],
+    "resources": [
+      {
+        "label": "MDN HTML",
+        "url": "https://developer.mozilla.org/en-US/docs/Learn/HTML"
+      },
+      {
+        "label": "Portfolio tips",
+        "url": "https://www.freecodecamp.org/news/portfolio-advice/"
+      }
+    ]
+  },
+  {
+    "day": 83,
+    "title": "Tic-Tac-Toe",
+    "stage": "portfolio",
+    "focus": [
+      "Games",
+      "Algorithms"
+    ],
+    "description": "Implement Tic-Tac-Toe with simple AI options.",
+    "concepts": [
+      "Game loops",
+      "State tracking",
+      "User feedback",
+      "Decision trees"
+    ],
+    "stretch": [
+      "Add scoring",
+      "Increase difficulty",
+      "Implement minimax"
+    ],
+    "resources": [
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      },
+      {
+        "label": "Algorithm basics",
+        "url": "https://visualgo.net/en"
+      }
+    ]
+  },
+  {
+    "day": 84,
+    "title": "Image Watermarking",
+    "stage": "portfolio",
+    "focus": [
+      "Pillow",
+      "Tkinter"
+    ],
+    "description": "Apply watermarks via a GUI.",
+    "concepts": [
+      "Image processing",
+      "Layers",
+      "Saving files",
+      "Widgets"
+    ],
+    "stretch": [
+      "Support batch edits",
+      "Allow custom fonts",
+      "Add styling"
+    ],
+    "resources": [
+      {
+        "label": "Pillow docs",
+        "url": "https://pillow.readthedocs.io/en/stable/"
+      },
+      {
+        "label": "Tkinter reference",
+        "url": "https://docs.python.org/3/library/tk.html"
+      }
+    ]
+  },
+  {
+    "day": 85,
+    "title": "Speed Typing Test",
+    "stage": "portfolio",
+    "focus": [
+      "Tkinter",
+      "Games"
+    ],
+    "description": "Measure typing speed with timers.",
+    "concepts": [
+      "Widgets",
+      "Layouts",
+      "Callbacks",
+      "Game loops"
+    ],
+    "stretch": [
+      "Add styling",
+      "Support keyboard shortcuts",
+      "Add scoring"
+    ],
+    "resources": [
+      {
+        "label": "Tkinter reference",
+        "url": "https://docs.python.org/3/library/tk.html"
+      },
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      }
+    ]
+  },
+  {
+    "day": 86,
+    "title": "Breakout Game",
+    "stage": "portfolio",
+    "focus": [
+      "Games",
+      "Tkinter"
+    ],
+    "description": "Recreate the classic Breakout arcade.",
+    "concepts": [
+      "Game loops",
+      "State tracking",
+      "User feedback",
+      "Widgets"
+    ],
+    "stretch": [
+      "Add scoring",
+      "Increase difficulty",
+      "Add styling"
+    ],
+    "resources": [
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      },
+      {
+        "label": "Tkinter reference",
+        "url": "https://docs.python.org/3/library/tk.html"
+      }
+    ]
+  },
+  {
+    "day": 87,
+    "title": "Cafés & Wifi API",
+    "stage": "portfolio",
+    "focus": [
+      "Flask",
+      "REST APIs"
+    ],
+    "description": "Offer café data via a RESTful API.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "HTTP verbs"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add docs"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "REST design",
+        "url": "https://restfulapi.net/"
+      }
+    ]
+  },
+  {
+    "day": 88,
+    "title": "To-Do App",
+    "stage": "portfolio",
+    "focus": [
+      "Flask",
+      "Auth"
+    ],
+    "description": "Build a full-stack to-do manager.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Hashing"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add roles"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "Flask-Login",
+        "url": "https://flask-login.readthedocs.io/"
+      }
+    ]
+  },
+  {
+    "day": 89,
+    "title": "Disappearing Text App",
+    "stage": "portfolio",
+    "focus": [
+      "Tkinter",
+      "Productivity"
+    ],
+    "description": "Keep typing or watch text vanish.",
+    "concepts": [
+      "Widgets",
+      "Layouts",
+      "Callbacks",
+      "Timers"
+    ],
+    "stretch": [
+      "Add styling",
+      "Support keyboard shortcuts",
+      "Track sessions"
+    ],
+    "resources": [
+      {
+        "label": "Tkinter reference",
+        "url": "https://docs.python.org/3/library/tk.html"
+      },
+      {
+        "label": "Pomodoro method",
+        "url": "https://todoist.com/productivity-methods/pomodoro-technique"
+      }
+    ]
+  },
+  {
+    "day": 90,
+    "title": "PDF → Audiobook",
+    "stage": "portfolio",
+    "focus": [
+      "Text-to-Speech",
+      "Automation"
+    ],
+    "description": "Turn PDF books into spoken audio.",
+    "concepts": [
+      "Audio output",
+      "Voice engines",
+      "File export",
+      "Scheduling"
+    ],
+    "stretch": [
+      "Support multiple voices",
+      "Add GUI",
+      "Add logging"
+    ],
+    "resources": [
+      {
+        "label": "pyttsx3",
+        "url": "https://pyttsx3.readthedocs.io/en/latest/"
+      },
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      }
+    ]
+  },
+  {
+    "day": 91,
+    "title": "Image Colour Palette",
+    "stage": "portfolio",
+    "focus": [
+      "Pillow",
+      "Visualisation"
+    ],
+    "description": "Extract colour palettes from images.",
+    "concepts": [
+      "Image processing",
+      "Layers",
+      "Saving files",
+      "Charts"
+    ],
+    "stretch": [
+      "Support batch edits",
+      "Allow custom fonts",
+      "Add interactivity"
+    ],
+    "resources": [
+      {
+        "label": "Pillow docs",
+        "url": "https://pillow.readthedocs.io/en/stable/"
+      },
+      {
+        "label": "Matplotlib",
+        "url": "https://matplotlib.org/stable/index.html"
+      }
+    ]
+  },
+  {
+    "day": 92,
+    "title": "Custom Web Scraper",
+    "stage": "portfolio",
+    "focus": [
+      "Scraping",
+      "Automation"
+    ],
+    "description": "Scrape any site with pagination handling.",
+    "concepts": [
+      "HTTP requests",
+      "Parsing",
+      "Throttling",
+      "Scheduling"
+    ],
+    "stretch": [
+      "Respect robots.txt",
+      "Add caching",
+      "Add logging"
+    ],
+    "resources": [
+      {
+        "label": "Scraping guide",
+        "url": "https://docs.python-guide.org/scenarios/scrape/"
+      },
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      }
+    ]
+  },
+  {
+    "day": 93,
+    "title": "Automate Chrome Dino",
+    "stage": "portfolio",
+    "focus": [
+      "Selenium",
+      "Games"
+    ],
+    "description": "Beat the Chrome Dino using automation.",
+    "concepts": [
+      "WebDriver",
+      "Locators",
+      "Automation",
+      "Game loops"
+    ],
+    "stretch": [
+      "Use explicit waits",
+      "Handle errors",
+      "Add scoring"
+    ],
+    "resources": [
+      {
+        "label": "Selenium docs",
+        "url": "https://www.selenium.dev/documentation/webdriver/"
+      },
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      }
+    ]
+  },
+  {
+    "day": 94,
+    "title": "Space Invaders",
+    "stage": "portfolio",
+    "focus": [
+      "Games",
+      "Tkinter"
+    ],
+    "description": "Create a retro Space Invaders clone.",
+    "concepts": [
+      "Game loops",
+      "State tracking",
+      "User feedback",
+      "Widgets"
+    ],
+    "stretch": [
+      "Add scoring",
+      "Increase difficulty",
+      "Add styling"
+    ],
+    "resources": [
+      {
+        "label": "Game design basics",
+        "url": "https://realpython.com/python-game-programming/"
+      },
+      {
+        "label": "Tkinter reference",
+        "url": "https://docs.python.org/3/library/tk.html"
+      }
+    ]
+  },
+  {
+    "day": 95,
+    "title": "Live Data Website",
+    "stage": "portfolio",
+    "focus": [
+      "APIs",
+      "Web"
+    ],
+    "description": "Display live data on a custom site.",
+    "concepts": [
+      "HTTP requests",
+      "JSON parsing",
+      "Endpoints",
+      "Structure"
+    ],
+    "stretch": [
+      "Handle errors",
+      "Add retries",
+      "Deploy site"
+    ],
+    "resources": [
+      {
+        "label": "requests docs",
+        "url": "https://requests.readthedocs.io/"
+      },
+      {
+        "label": "MDN Web",
+        "url": "https://developer.mozilla.org/en-US/docs/Learn"
+      }
+    ]
+  },
+  {
+    "day": 96,
+    "title": "eCommerce Demo",
+    "stage": "portfolio",
+    "focus": [
+      "Flask",
+      "Payments"
+    ],
+    "description": "Prototype a checkout flow with Stripe.",
+    "concepts": [
+      "Routing",
+      "Templates",
+      "Context",
+      "Checkout flow"
+    ],
+    "stretch": [
+      "Add blueprint",
+      "Implement tests",
+      "Add coupons"
+    ],
+    "resources": [
+      {
+        "label": "Flask docs",
+        "url": "https://flask.palletsprojects.com/"
+      },
+      {
+        "label": "Stripe docs",
+        "url": "https://stripe.com/docs/api"
+      }
+    ]
+  },
+  {
+    "day": 97,
+    "title": "WhatsApp Automation",
+    "stage": "portfolio",
+    "focus": [
+      "Automation",
+      "APIs"
+    ],
+    "description": "Schedule WhatsApp messages programmatically.",
+    "concepts": [
+      "Scheduling",
+      "APIs",
+      "Workflows",
+      "HTTP requests"
+    ],
+    "stretch": [
+      "Add logging",
+      "Deploy to cloud",
+      "Handle errors"
+    ],
+    "resources": [
+      {
+        "label": "Automate the Boring Stuff",
+        "url": "https://automatetheboringstuff.com/"
+      },
+      {
+        "label": "requests docs",
+        "url": "https://requests.readthedocs.io/"
+      }
+    ]
+  },
+  {
+    "day": 98,
+    "title": "Space Race Visualisation",
+    "stage": "portfolio",
+    "focus": [
+      "Plotly",
+      "Data Viz"
+    ],
+    "description": "Chart the space race timeline interactively.",
+    "concepts": [
+      "Interactive charts",
+      "Dashboards",
+      "Styling",
+      "Storytelling"
+    ],
+    "stretch": [
+      "Add filters",
+      "Embed visuals",
+      "Add annotations"
+    ],
+    "resources": [
+      {
+        "label": "Plotly docs",
+        "url": "https://plotly.com/python/"
+      },
+      {
+        "label": "Data Viz Handbook",
+        "url": "https://datavizcatalogue.com/"
+      }
+    ]
+  },
+  {
+    "day": 99,
+    "title": "Police Violence Analysis",
+    "stage": "portfolio",
+    "focus": [
+      "Data Ethics",
+      "pandas"
+    ],
+    "description": "Analyse police-involved incidents responsibly.",
+    "concepts": [
+      "Bias",
+      "Transparency",
+      "Context",
+      "DataFrame basics"
+    ],
+    "stretch": [
+      "Add disclaimers",
+      "Discuss limitations",
+      "Create charts"
+    ],
+    "resources": [
+      {
+        "label": "Data ethics",
+        "url": "https://datasociety.net/library/data-ethics/"
+      },
+      {
+        "label": "pandas docs",
+        "url": "https://pandas.pydata.org/docs/"
+      }
+    ]
+  },
+  {
+    "day": 100,
+    "title": "Predict Earnings",
+    "stage": "portfolio",
+    "focus": [
+      "Machine Learning",
+      "Regression"
+    ],
+    "description": "Model earnings with multivariable regression.",
+    "concepts": [
+      "Modeling",
+      "Feature engineering",
+      "Evaluation",
+      "Linear models"
+    ],
+    "stretch": [
+      "Tune hyperparameters",
+      "Compare algorithms",
+      "Add regularisation"
+    ],
+    "resources": [
+      {
+        "label": "scikit-learn",
+        "url": "https://scikit-learn.org/stable/"
+      },
+      {
+        "label": "Regression guide",
+        "url": "https://realpython.com/linear-regression-in-python/"
+      }
+    ]
+  }
+];
+
+export const focusLabels = {
+  "Python Basics": "Python Basics",
+  "Strings": "Strings & Text",
+  "Math": "Math & Numbers",
+  "Conditionals": "Control Flow",
+  "Games": "Game Dev",
+  "Randomness": "Randomness",
+  "Security": "Security",
+  "Functions": "Functions",
+  "Problem Solving": "Problem Solving",
+  "Loops": "Loops",
+  "Dictionaries": "Dictionaries",
+  "CLI": "Command Line",
+  "Logic": "Logic",
+  "Scope": "Scope & Constants",
+  "Debugging": "Debugging",
+  "Mindset": "Mindset",
+  "APIs": "APIs",
+  "Procedural": "Procedural Design",
+  "OOP": "Object-Oriented",
+  "Trivia": "Trivia",
+  "Turtle": "Turtle Graphics",
+  "Events": "Events",
+  "File I/O": "File I/O",
+  "pandas": "pandas",
+  "CSV": "CSV & Data",
+  "Comprehensions": "Comprehensions",
+  "Tkinter": "Tkinter GUI",
+  "GUI": "GUI",
+  "Productivity": "Productivity",
+  "Persistence": "Persistence",
+  "Learning": "Learning",
+  "Automation": "Automation",
+  "Email": "Email",
+  "Google Sheets": "Google Sheets",
+  "Finance": "Finance",
+  "Visualisation": "Visualisation",
+  "HTML/CSS": "HTML & CSS",
+  "Web": "Web",
+  "Design": "Design",
+  "BeautifulSoup": "BeautifulSoup",
+  "Scraping": "Scraping",
+  "Selenium": "Selenium",
+  "Flask": "Flask",
+  "Blog": "Blog",
+  "Bootstrap": "Bootstrap",
+  "Design Systems": "Design Systems",
+  "Deploy": "Deployment",
+  "DevOps": "DevOps",
+  "Databases": "Databases",
+  "REST APIs": "REST APIs",
+  "Auth": "Authentication",
+  "Forms": "Forms",
+  "Portfolio": "Portfolio",
+  "Pillow": "Pillow",
+  "Text-to-Speech": "Text-to-Speech",
+  "Plotly": "Plotly",
+  "Machine Learning": "Machine Learning",
+  "Regression": "Regression",
+  "Data Viz": "Data Visualisation",
+  "Statistics": "Statistics",
+  "Hypothesis Testing": "Hypothesis Testing",
+  "NumPy": "NumPy",
+  "Arrays": "Arrays",
+  "Seaborn": "Seaborn",
+  "Time Series": "Time Series",
+  "Data Ethics": "Data Ethics",
+  "Algorithms": "Algorithms",
+  "Payments": "Payments",
+  "EDA": "Exploratory Data Analysis"
+};

--- a/script.js
+++ b/script.js
@@ -1,0 +1,293 @@
+import { stages, lessons, focusLabels } from './lessons-data.js';
+
+const storageKey = 'python-100-progress';
+
+const state = {
+  stage: new Set(),
+  focus: new Set(),
+  search: '',
+  incompleteOnly: false,
+  completedDays: new Set(loadProgress()),
+};
+
+const stageFiltersContainer = document.querySelector('#stageFilters');
+const focusFiltersContainer = document.querySelector('#focusFilters');
+const cardsContainer = document.querySelector('#cards');
+const cardTemplate = document.querySelector('#cardTemplate');
+const searchInput = document.querySelector('#searchInput');
+const completedToggle = document.querySelector('#completedToggle');
+const completedCountEl = document.querySelector('#completedCount');
+const progressPercentEl = document.querySelector('#progressPercent');
+const progressBarEl = document.querySelector('#progressBar');
+const toggleTimelineBtn = document.querySelector('#toggleTimeline');
+const timelineSection = document.querySelector('#timelineSection');
+const timelineContainer = document.querySelector('#timeline');
+const resetProgressBtn = document.querySelector('#resetProgress');
+
+renderFilters();
+renderTimeline();
+renderCards();
+updateProgress();
+
+searchInput.addEventListener('input', (event) => {
+  state.search = event.target.value.toLowerCase();
+  renderCards();
+});
+
+completedToggle.addEventListener('change', (event) => {
+  state.incompleteOnly = event.target.checked;
+  renderCards();
+});
+
+toggleTimelineBtn.addEventListener('click', () => {
+  const hidden = timelineSection.hasAttribute('hidden');
+  if (hidden) {
+    timelineSection.removeAttribute('hidden');
+    toggleTimelineBtn.textContent = 'Hide Timeline';
+  } else {
+    timelineSection.setAttribute('hidden', '');
+    toggleTimelineBtn.textContent = 'Show Timeline';
+  }
+});
+
+resetProgressBtn.addEventListener('click', () => {
+  if (confirm('Reset all completed days?')) {
+    state.completedDays.clear();
+    saveProgress();
+    renderCards();
+    updateProgress();
+  }
+});
+
+function renderFilters() {
+  stages.forEach((stage) => {
+    const chip = createChip(stage.label, () => {
+      toggleFilter(state.stage, stage.id);
+      renderCards();
+    });
+    chip.dataset.value = stage.id;
+    stageFiltersContainer.appendChild(chip);
+  });
+
+  const sortedFocus = Object.keys(focusLabels).sort((a, b) =>
+    (focusLabels[a] || a).localeCompare(focusLabels[b] || b)
+  );
+
+  sortedFocus.forEach((focus) => {
+    const chip = createChip(focusLabels[focus] || focus, () => {
+      toggleFilter(state.focus, focus);
+      renderCards();
+    });
+    chip.dataset.value = focus;
+    focusFiltersContainer.appendChild(chip);
+  });
+}
+
+function createChip(label, onClick) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'chip';
+  button.setAttribute('aria-pressed', 'false');
+  button.textContent = label;
+  button.addEventListener('click', () => {
+    const pressed = button.getAttribute('aria-pressed') === 'true';
+    button.setAttribute('aria-pressed', pressed ? 'false' : 'true');
+    onClick();
+  });
+  return button;
+}
+
+function toggleFilter(set, value) {
+  if (set.has(value)) {
+    set.delete(value);
+  } else {
+    set.add(value);
+  }
+}
+
+function renderCards() {
+  cardsContainer.innerHTML = '';
+
+  const filtered = lessons.filter((lesson) => {
+    const matchesStage = state.stage.size === 0 || state.stage.has(lesson.stage);
+    const matchesFocus =
+      state.focus.size === 0 || lesson.focus.some((focus) => state.focus.has(focus));
+    const matchesSearch =
+      state.search === '' ||
+      [lesson.title, lesson.description, ...lesson.focus]
+        .join(' ')
+        .toLowerCase()
+        .includes(state.search);
+    const isCompleted = state.completedDays.has(String(lesson.day));
+    const matchesIncomplete = !state.incompleteOnly || !isCompleted;
+
+    return matchesStage && matchesFocus && matchesSearch && matchesIncomplete;
+  });
+
+  if (filtered.length === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No lessons match your filters. Try adjusting the criteria.';
+    empty.className = 'empty';
+    cardsContainer.appendChild(empty);
+    return;
+  }
+
+  filtered.forEach((lesson) => {
+    const card = cardTemplate.content.firstElementChild.cloneNode(true);
+    const dayEl = card.querySelector('.card__day');
+    const titleEl = card.querySelector('.card__title');
+    const metaEl = card.querySelector('.card__meta');
+    const descriptionEl = card.querySelector('.card__description');
+    const conceptsEl = card.querySelector('.card__concepts');
+    const resourcesEl = card.querySelector('.card__resources');
+    const checkbox = card.querySelector("input[type='checkbox']");
+    const toggleButton = card.querySelector('.card__toggle');
+    const body = card.querySelector('.card__body');
+
+    dayEl.textContent = `Day ${lesson.day}`;
+    titleEl.textContent = lesson.title;
+    metaEl.innerHTML = '';
+    metaEl.appendChild(createMetaTag(getStageLabel(lesson.stage)));
+    lesson.focus.forEach((focus) => {
+      metaEl.appendChild(createMetaTag(focusLabels[focus] || focus));
+    });
+
+    descriptionEl.textContent = lesson.description;
+
+    conceptsEl.innerHTML = '';
+    lesson.concepts.forEach((concept) => {
+      const li = document.createElement('li');
+      li.textContent = concept;
+      conceptsEl.appendChild(li);
+    });
+
+    resourcesEl.innerHTML = '';
+    lesson.resources.forEach((resource) => {
+      const link = document.createElement('a');
+      link.href = resource.url;
+      link.target = '_blank';
+      link.rel = 'noopener';
+      link.textContent = resource.label;
+      resourcesEl.appendChild(link);
+    });
+
+    if (lesson.stretch?.length) {
+      const stretchHeading = document.createElement('p');
+      stretchHeading.className = 'card__stretch-heading';
+      stretchHeading.textContent = 'Stretch ideas:';
+      body.appendChild(stretchHeading);
+
+      const stretchList = document.createElement('ul');
+      stretchList.className = 'card__stretch';
+      lesson.stretch.forEach((idea) => {
+        const li = document.createElement('li');
+        li.textContent = idea;
+        stretchList.appendChild(li);
+      });
+      body.appendChild(stretchList);
+    }
+
+    const isCompleted = state.completedDays.has(String(lesson.day));
+    checkbox.checked = isCompleted;
+
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) {
+        state.completedDays.add(String(lesson.day));
+      } else {
+        state.completedDays.delete(String(lesson.day));
+      }
+      saveProgress();
+      updateProgress();
+      if (state.incompleteOnly && checkbox.checked) {
+        card.remove();
+        updateEmptyState();
+      }
+    });
+
+    toggleButton.addEventListener('click', () => {
+      const expanded = toggleButton.getAttribute('aria-expanded') === 'true';
+      toggleButton.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      body.hidden = expanded;
+    });
+
+    cardsContainer.appendChild(card);
+  });
+
+  updateEmptyState();
+}
+
+function createMetaTag(text) {
+  const span = document.createElement('span');
+  span.textContent = text;
+  return span;
+}
+
+function getStageLabel(stageId) {
+  return stages.find((stage) => stage.id === stageId)?.label || stageId;
+}
+
+function renderTimeline() {
+  timelineContainer.innerHTML = '';
+  stages.forEach((stage) => {
+    const section = document.createElement('div');
+    section.className = 'timeline__stage';
+
+    const heading = document.createElement('h3');
+    heading.textContent = stage.label;
+    section.appendChild(heading);
+
+    const summary = document.createElement('p');
+    summary.textContent = stage.summary;
+    section.appendChild(summary);
+
+    const range = document.createElement('p');
+    range.innerHTML = `<strong>Days:</strong> ${stage.range}`;
+    section.appendChild(range);
+
+    const highlights = document.createElement('p');
+    const highlightsText = lessons
+      .filter((lesson) => lesson.stage === stage.id)
+      .slice(0, 3)
+      .map((lesson) => lesson.title)
+      .join(', ');
+    highlights.innerHTML = `<strong>Highlights:</strong> ${highlightsText}...`;
+    section.appendChild(highlights);
+
+    timelineContainer.appendChild(section);
+  });
+}
+
+function updateProgress() {
+  const completed = state.completedDays.size;
+  const total = lessons.length;
+  const percent = Math.round((completed / total) * 100);
+
+  completedCountEl.textContent = completed;
+  progressPercentEl.textContent = `${percent}%`;
+  progressBarEl.style.width = `${percent}%`;
+
+  saveProgress();
+}
+
+function updateEmptyState() {
+  if (cardsContainer.children.length === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = 'All matching lessons are complete. Great job!';
+    empty.className = 'empty';
+    cardsContainer.appendChild(empty);
+  }
+}
+
+function loadProgress() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(storageKey) || '[]');
+    return Array.isArray(saved) ? saved : [];
+  } catch (error) {
+    console.warn('Failed to load progress', error);
+    return [];
+  }
+}
+
+function saveProgress() {
+  localStorage.setItem(storageKey, JSON.stringify(Array.from(state.completedDays)));
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,417 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0e1726;
+  --bg-alt: rgba(14, 23, 38, 0.85);
+  --surface: rgba(255, 255, 255, 0.04);
+  --card: rgba(255, 255, 255, 0.08);
+  --text: #e6ecff;
+  --text-muted: rgba(230, 236, 255, 0.75);
+  --accent: #7b5bff;
+  --accent-strong: #c77dff;
+  --border: rgba(255, 255, 255, 0.12);
+  --shadow: 0 16px 30px rgba(15, 23, 42, 0.32);
+  --radius-xl: 32px;
+  --radius-lg: 18px;
+  --radius-md: 12px;
+  --radius-sm: 8px;
+  --transition: 160ms ease-in-out;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Fira Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top left, #1f2a44, var(--bg));
+  color: var(--text);
+  min-height: 100vh;
+  line-height: 1.5;
+  padding-bottom: 4rem;
+}
+
+h1, h2, h3 {
+  margin: 0;
+  font-weight: 600;
+}
+
+p {
+  margin: 0;
+}
+
+a {
+  color: var(--accent-strong);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.hero {
+  display: grid;
+  gap: 2rem;
+  padding: 4rem clamp(1.5rem, 3vw, 3.5rem) 2rem;
+  background: linear-gradient(140deg, rgba(123, 91, 255, 0.18), rgba(199, 125, 255, 0.08));
+}
+
+.hero__content {
+  max-width: 720px;
+}
+
+.hero__content p {
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  margin-block: 0.75rem 1.5rem;
+}
+
+.hero__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.hero__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.stat-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.stat-card__label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.stat-card__value {
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  font-weight: 700;
+}
+
+.stat-card__subvalue {
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.progress {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  height: 0.75rem;
+  overflow: hidden;
+}
+
+.progress__bar {
+  background: linear-gradient(120deg, var(--accent), var(--accent-strong));
+  height: 100%;
+  width: 0%;
+  transition: width var(--transition);
+}
+
+main {
+  display: grid;
+  gap: 2rem;
+  padding: 0 clamp(1.5rem, 3vw, 3.5rem);
+}
+
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.panel--filters {
+  gap: 1.25rem;
+}
+
+.panel__header p {
+  color: var(--text-muted);
+}
+
+.filter-group {
+  display: grid;
+  gap: 0.5rem;
+  align-items: start;
+}
+
+.filter-group__label {
+  font-weight: 500;
+}
+
+input[type="search"] {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: rgba(14, 23, 38, 0.6);
+  color: var(--text);
+  font-size: 1rem;
+}
+
+input[type="search"]:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.toggle input {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.btn {
+  border: none;
+  padding: 0.75rem 1.4rem;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(123, 91, 255, 0.35);
+}
+
+.btn--ghost {
+  background: transparent;
+  border: 1px solid var(--accent);
+  color: var(--accent-strong);
+}
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.chip {
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), border var(--transition);
+  font-size: 0.95rem;
+}
+
+.chip[aria-pressed="true"] {
+  background: var(--accent);
+  border-color: transparent;
+  color: white;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.4rem;
+  border-radius: var(--radius-lg);
+  background: var(--card);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  transition: transform var(--transition), border var(--transition), background var(--transition);
+  position: relative;
+}
+
+.card:hover,
+.card:focus-within {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.card__day {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.card__title {
+  font-size: 1.2rem;
+  margin-top: 0.25rem;
+}
+
+.card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.card__meta span {
+  background: rgba(123, 91, 255, 0.14);
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+}
+
+.card__checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.card__checkbox input {
+  accent-color: var(--accent);
+  width: 1rem;
+  height: 1rem;
+}
+
+.card__toggle {
+  justify-self: flex-start;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background var(--transition), color var(--transition);
+}
+
+.card__toggle[aria-expanded="true"] {
+  background: rgba(123, 91, 255, 0.26);
+  color: white;
+}
+
+.card__body {
+  display: grid;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.card__concepts {
+  display: grid;
+  gap: 0.4rem;
+  padding-left: 1.2rem;
+}
+
+.card__resources {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.card__stretch-heading {
+  font-weight: 600;
+  margin-top: 0.5rem;
+}
+
+.card__stretch {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.card__resources a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: inherit;
+  font-weight: 500;
+}
+
+.card__resources a::before {
+  content: "→";
+  color: var(--accent-strong);
+}
+
+.timeline {
+  display: grid;
+  gap: 1rem;
+}
+
+.timeline__stage {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.timeline__stage h3 {
+  font-size: 1rem;
+}
+
+.timeline__stage p {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.empty {
+  text-align: center;
+  color: var(--text-muted);
+  font-style: italic;
+  padding: 1rem;
+}
+
+footer {
+  text-align: center;
+  margin-top: 3rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding-top: 3rem;
+  }
+  .cards {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+@media (max-width: 540px) {
+  .hero {
+    padding: 2.5rem 1.25rem 1.5rem;
+  }
+  main {
+    padding-inline: 1.25rem;
+  }
+  .panel {
+    border-radius: var(--radius-lg);
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page layout with hero stats, filters, and a reusable card template for the 100 Days of Code lessons
- generate a structured dataset covering all 100 lessons with stages, focus tags, concepts, stretch goals, and resources
- implement client-side filtering, progress tracking with localStorage, and a stage timeline view for planning

## Testing
- No automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d492430b5c832183d0a317df0d2ebb